### PR TITLE
fix:  enable reset date picker field

### DIFF
--- a/packages/react-components/src/components/date-picker/date-picker.tsx
+++ b/packages/react-components/src/components/date-picker/date-picker.tsx
@@ -32,7 +32,7 @@ export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
     local,
     onChange,
     showTime = DEFAULTS.DATE_PICKER.showTime,
-    value: propValue,
+    value,
     ...resProps
   } = props;
 
@@ -55,7 +55,7 @@ export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
             variant={variant as WrapperVariant}
             placeholder={placeHolderText}
             onChange={handleOnChange}
-            value={props.value}
+            value={value}
             disableFuture={disableFuture}
             format={format}
             {...resProps}
@@ -66,7 +66,7 @@ export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
             variant={variant as WrapperVariant}
             placeholder={placeHolderText}
             onChange={handleOnChange}
-            value={props.value}
+            value={value}
             disableFuture={disableFuture}
             format={format}
             {...resProps}

--- a/packages/react-components/src/components/date-picker/date-picker.tsx
+++ b/packages/react-components/src/components/date-picker/date-picker.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { he, enUS } from 'date-fns/locale';
 import { MuiPickersUtilsProvider, KeyboardDateTimePicker, KeyboardDatePicker, KeyboardDatePickerProps } from '@material-ui/pickers';
-import { ParsableDate } from '@material-ui/pickers/constants/prop-types';
 import { WrapperVariant } from '@material-ui/pickers/wrappers/Wrapper';
 import DateFnsUtils from '@date-io/date-fns';
 import { ThemeProvider } from '@material-ui/core';
@@ -25,7 +24,6 @@ export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
   const theme = useTheme();
   const themeMui = useMappedMuiTheme(theme);
 
-  const [value, setValue] = useState<ParsableDate>(props.value);
 
   const {
     format = DEFAULTS.DATE_PICKER.dateFormat,
@@ -46,7 +44,6 @@ export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
   const locale = calendarLocale === SupportedLocales.HE ? he : enUS;
 
   const handleOnChange = (e: any): void => {
-    setValue(e);
     onChange(e as Date);
   };
 
@@ -58,7 +55,7 @@ export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
             variant={variant as WrapperVariant}
             placeholder={placeHolderText}
             onChange={handleOnChange}
-            value={value}
+            value={props.value}
             disableFuture={disableFuture}
             format={format}
             {...resProps}
@@ -69,7 +66,7 @@ export const DateTimePicker: React.FC<DatePickerProps> = (props) => {
             variant={variant as WrapperVariant}
             placeholder={placeHolderText}
             onChange={handleOnChange}
-            value={value}
+            value={props.value}
             disableFuture={disableFuture}
             format={format}
             {...resProps}


### PR DESCRIPTION
Delete unnecessary useState in date-picker.tsx in order to enable reset date picker field